### PR TITLE
use map instead of unordered_map to avoid newer libstdc++ dependency

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -2,7 +2,7 @@
 #include <string>
 #include <memory>
 #include <vector>
-#include <unordered_map>
+#include <map>
 #include <node.h>
 #include <nan.h>
 
@@ -46,7 +46,7 @@ public:
 
     rd_kafka_type_t ktype_;
     rd_kafka_t *kafka_client_;
-    std::unordered_map<std::string, rd_kafka_topic_t*> topics_;
+    std::map<std::string, rd_kafka_topic_t*> topics_;
 
     // callbacks
     std::unique_ptr<NanCallback> stat_event_callback_;


### PR DESCRIPTION
using unordered_map caused a symbol dependency for:
_ZNKSt8__detail20_Prime_r@GLIBCXX_3.4.18

or similar for GLIBCXX_3.4.19, depending on exact g++ used.
