### PR TITLE
Fixing binding.gyp to work on Mac OS X 10.11

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,7 +20,8 @@
           'OS=="mac"',
           {
             'xcode_settings': {
-              'MACOSX_DEPLOYMENT_TARGET': '10.11'
+              'MACOSX_DEPLOYMENT_TARGET': '10.11',
+              'OTHER_CPLUSPLUSFLAGS' : ['-std=c++11']
             },
             'libraries' : ['-lz']
           }


### PR DESCRIPTION
Adding -std=c++11 to xcpde compiler settings,
to avoid this error :
In file included from ../src/common.h:6:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/atomic:543:2:
error: <atomic> is not implemented
